### PR TITLE
Make punctuation use `SeparatedBy` + Fix failing test

### DIFF
--- a/lang/src/syntax/application.rs
+++ b/lang/src/syntax/application.rs
@@ -10,7 +10,7 @@
 //!
 
 use avpony_macros::Spanned;
-use chumsky::{text, Parser};
+use chumsky::{primitive::just, text, Parser};
 
 use crate::utils::{PonyParser, Span};
 
@@ -22,11 +22,10 @@ pub struct Application {
 }
 
 impl Application {
-    pub fn parse_with(
-        expr: impl PonyParser<super::Expr> + Clone,
-    ) -> impl PonyParser<Self> + Clone {
+    pub fn parse_with(expr: impl PonyParser<super::Expr> + Clone) -> impl PonyParser<Self> + Clone {
         expr.clone()
             .map(Box::new)
+            .then_ignore(just("[").not().rewind())
             .padded_by(text::whitespace())
             .then(expr.map(Box::new))
             .map_with_span(|(function, argument), span| Self {

--- a/lang/src/syntax/index.rs
+++ b/lang/src/syntax/index.rs
@@ -19,9 +19,7 @@ pub struct Indexing {
 }
 
 impl Indexing {
-    pub fn parse_with(
-        expr: impl PonyParser<super::Expr> + Clone,
-    ) -> impl PonyParser<Self> + Clone {
+    pub fn parse_with(expr: impl PonyParser<super::Expr> + Clone) -> impl PonyParser<Self> + Clone {
         expr.clone()
             .then(expr.padded().delimited_by(just("["), just("]")))
             .map_with_span(|(receiver, index), span| Self {
@@ -53,6 +51,10 @@ mod tests {
                 index: box Expr::Literal(Literal::String(key)),
                 ..
             })) if (&ident == "dict") && (&key == "key")
-        ))
+        ));
+
+        let (source, _) = SourceFile::test_file(r#"func ["arg1", "arg2", "arg3"]"#);
+        let res = Expr::parser().parse(source.stream());
+        assert!(matches!(res, Ok(Expr::Application(_))))
     }
 }

--- a/lang/src/syntax/utils.rs
+++ b/lang/src/syntax/utils.rs
@@ -58,17 +58,20 @@ impl<Token, Punct: ParseableExt> Punctuated<Token, Punct> {
         inner
             .clone()
             .then_ignore(text::whitespace())
-            .then_ignore(just(",").padded())
-            .repeated()
-            .then(inner.or_not())
-            .map_with_span(|(mut inner, after), span| Self {
+            .separated_by(just(",").padded())
+            .allow_trailing()
+            .map_with_span(|inner, span| Self {
                 span,
-                inner: {
-                    inner.extend(after);
-                    inner
-                },
+                inner,
                 __marker: PhantomData,
             })
+    }
+
+    pub fn optional_trailing() -> impl PonyParser<Self> + Clone
+    where
+        Token: ParseableExt,
+    {
+        Self::optional_trailing_with(Token::parser())
     }
 }
 


### PR DESCRIPTION
Fixes #5 
See individual commits for more info.