### PR TITLE
Make all non-`Span` fields public in syntax nodes.

### DIFF
--- a/lang/src/lexical/identifier.rs
+++ b/lang/src/lexical/identifier.rs
@@ -33,7 +33,7 @@ use super::keyword;
 #[derive(Debug, Clone, Spanned, PartialEq)]
 pub struct UncheckedIdentifier {
     span: Span,
-    value: String,
+    pub value: String,
 }
 
 impl ParseableExt for UncheckedIdentifier {
@@ -61,7 +61,7 @@ impl ParseableExt for UncheckedIdentifier {
 #[derive(Debug, Clone, Spanned, PartialEq)]
 pub struct Identifier {
     span: Span,
-    value: String,
+    pub value: String,
 }
 
 impl ParseableExt for Identifier {

--- a/lang/src/lexical/string.rs
+++ b/lang/src/lexical/string.rs
@@ -64,7 +64,7 @@ use crate::utils::{
 
 #[derive(Debug, Clone, Spanned, PartialEq)]
 pub struct StringLit {
-    pub span: Span,
+    span: Span,
     pub value: String,
 }
 impl ParseableExt for StringLit {

--- a/lang/src/syntax/application.rs
+++ b/lang/src/syntax/application.rs
@@ -17,8 +17,8 @@ use crate::utils::{PonyParser, Span};
 #[derive(Debug, Clone, Spanned, PartialEq)]
 pub struct Application {
     span: Span,
-    function: Box<super::Expr>,
-    argument: Box<super::Expr>,
+    pub function: Box<super::Expr>,
+    pub argument: Box<super::Expr>,
 }
 
 impl Application {

--- a/lang/src/syntax/array.rs
+++ b/lang/src/syntax/array.rs
@@ -18,7 +18,7 @@ use super::utils::Punctuated;
 #[derive(Debug, Clone, Spanned, PartialEq)]
 pub struct Array {
     span: Span,
-    contents: Punctuated<super::Expr, punctuation::Comma>,
+    pub contents: Punctuated<super::Expr, punctuation::Comma>,
 }
 
 impl Array {

--- a/lang/src/syntax/index.rs
+++ b/lang/src/syntax/index.rs
@@ -14,8 +14,8 @@ use crate::utils::{PonyParser, Span};
 #[derive(Debug, Clone, Spanned, PartialEq)]
 pub struct Indexing {
     span: Span,
-    receiver: Box<super::Expr>,
-    index: Box<super::Expr>,
+    pub receiver: Box<super::Expr>,
+    pub index: Box<super::Expr>,
 }
 
 impl Indexing {

--- a/lang/src/syntax/map.rs
+++ b/lang/src/syntax/map.rs
@@ -29,7 +29,7 @@ use super::utils::Punctuated;
 #[derive(Debug, Clone, Spanned, PartialEq)]
 pub struct Map {
     span: Span,
-    fields: Punctuated<Field, punctuation::Comma>,
+    pub fields: Punctuated<Field, punctuation::Comma>,
 }
 
 impl Map {

--- a/lang/src/syntax/member.rs
+++ b/lang/src/syntax/member.rs
@@ -17,7 +17,7 @@ use crate::{
 
 #[derive(Debug, Clone, Spanned, PartialEq)]
 pub struct MemberAccess {
-    pub span: Span,
+    span: Span,
     pub receiver: Box<super::Expr>,
     pub member: lexical::Identifier,
 }

--- a/lang/src/syntax/operation.rs
+++ b/lang/src/syntax/operation.rs
@@ -16,8 +16,8 @@ use super::operator::BinaryOperator;
 #[derive(Debug, Clone, Spanned, PartialEq)]
 pub struct BinaryOperation {
     span: Span,
-    operator: BinaryOperator,
-    operands: [Box<super::Expr>; 2],
+    pub operator: BinaryOperator,
+    pub operands: [Box<super::Expr>; 2],
 }
 
 impl BinaryOperation {

--- a/lang/src/syntax/parenthesized.rs
+++ b/lang/src/syntax/parenthesized.rs
@@ -18,7 +18,7 @@ use crate::utils::{PonyParser, Span};
 
 #[derive(Debug, Clone, Spanned, PartialEq)]
 pub struct Parenthesized {
-    pub span: Span,
+    span: Span,
     pub inner: Box<super::Expr>,
 }
 

--- a/lang/src/syntax/tuple.rs
+++ b/lang/src/syntax/tuple.rs
@@ -22,7 +22,7 @@ use super::utils::Punctuated;
 #[derive(Debug, Clone, Spanned, PartialEq)]
 pub struct Tuple {
     span: Span,
-    items: Vec<super::Expr>,
+    pub items: Vec<super::Expr>,
 }
 
 impl Tuple {

--- a/lang/src/syntax/utils.rs
+++ b/lang/src/syntax/utils.rs
@@ -19,7 +19,7 @@ use crate::utils::{ParseableExt, PonyParser, Span};
 ///
 #[derive(Debug, Clone, Spanned, PartialEq)]
 pub struct Punctuated<Token, Punct> {
-    pub span: Span,
+    span: Span,
     pub inner: Vec<Token>,
     __marker: PhantomData<Punct>,
 }


### PR DESCRIPTION
Fixes #3 